### PR TITLE
Removed version param from module calling in 0-bootstrap

### DIFF
--- a/0-bootstrap/gh-runner.tf
+++ b/0-bootstrap/gh-runner.tf
@@ -16,7 +16,6 @@
 
 module "runner-mig" {
   source              = "../modules/terraform-google-github-actions-runners/modules/gh-runner-mig-vm"
-  version             = "1.0.0"
   create_network      = true
   project_id          = module.cloudbuild_bootstrap.cloudbuild_project_id
   repo_name           = var.runner_repo_name
@@ -34,4 +33,3 @@ module "runner-mig" {
 
   depends_on = [google_project_iam_member.rnr_sa_prj_perms]
 }
-

--- a/0-bootstrap/main.tf
+++ b/0-bootstrap/main.tf
@@ -25,7 +25,6 @@ resource "google_folder" "bootstrap" {
 
 module "seed_bootstrap" {
   source                         = "../modules/terraform-google-bootstrap"
-  version                        = "1.0.0"
   org_id                         = var.org_id
   folder_id                      = google_folder.bootstrap.id
   project_id                     = "${var.project_prefix}-${var.bootstrap_env_code}-seed"
@@ -104,7 +103,6 @@ resource "google_billing_account_iam_member" "tf_billing_admin" {
 
 module "cloudbuild_bootstrap" {
   source                      = "../modules/cloudbuild"
-  version                     = "1.0.0"
   create_cloud_source_repos   = false
   org_id                      = var.org_id
   folder_id                   = google_folder.bootstrap.id


### PR DESCRIPTION
This version parameter in module calling is causing below error:

> ╷
> │ Error: Invalid registry module source address
> │ 
> │ Module "cloudbuild_bootstrap" (declared at main.tf line 105) has invalid
> │ source address "../modules/cloudbuild": can't use local directory
> │ "../modules/cloudbuild" as a module registry address.
> │ 
> │ Terraform assumed that you intended a module registry source address because
> │ you also set the argument "version", which applies only to registry modules.
> ╵
> 

